### PR TITLE
Fix für Seitenheader

### DIFF
--- a/src/base/Preamble.tex
+++ b/src/base/Preamble.tex
@@ -73,6 +73,11 @@
         \setlength{\parindent}{0pt}
         \pagestyle{scrheadings}
 
+        \AtBeginDocument{%
+            \addtocontents{lof}{\protect\markboth{\listfigurename}{\listfigurename}}%
+            \addtocontents{lot}{\protect\markboth{\listtablename}{\listtablename}}%
+        }
+
 
 % Bibliography
 \usepackage[backend=biber, style=apa]{biblatex}


### PR DESCRIPTION
Seitenheader zeigt jetzt jeweils lot und lof an.
![WhatsApp Bild 2025-03-27 um 13 39 18_ee5c83d7](https://github.com/user-attachments/assets/21e72e04-bec5-480f-9480-3e9785698998)
Fix for [Issue #1](https://github.com/teismar/LFH_LaTeX_Template/issues/1)